### PR TITLE
Change maximum Advancement goal to 122

### DIFF
--- a/worlds/minecraft/Options.py
+++ b/worlds/minecraft/Options.py
@@ -6,7 +6,7 @@ class AdvancementGoal(Range):
     """Number of advancements required to spawn bosses."""
     display_name = "Advancement Goal"
     range_start = 0
-    range_end = 114
+    range_end = 122
     default = 40
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Changes the maximum range of the Advancement goal to 122 in order to match the 8 new 1.20 Advancements.

## How was this tested?
Ran a generation with the goal set at 122 and it succeeded.