### PR TITLE
Make Sniffer locations no longer hard

### DIFF
--- a/worlds/minecraft/data/excluded_locations.json
+++ b/worlds/minecraft/data/excluded_locations.json
@@ -16,9 +16,6 @@
         "Star Trader",
         "When the Squad Hops into Town",
         "With Our Powers Combined!",
-	"Smells Interesting",
-	"Little Sniffs",
-	"Planting the Past",
 	"Smithing with Style",
 	"Careful Restoration"
     ],


### PR DESCRIPTION
## What is this fixing or adding?
Removes Smells Interesting, Little Sniffs and Planting the Past from the list of hard Advancements.

## How was this tested?
Has not been.