### PR TITLE
Add alternate Enchanting requirement to Smithing with Style

### DIFF
--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -280,7 +280,7 @@ def get_rules_lookup(player: int):
                 state.can_reach("End City", 'Region', player) and  # Spire Armor Trim
                 state.has("Progressive Tools", player, 2) and  # Ward and Silence Armor Trims
                 ((state.has("Fishing Rod", player) and can_brew_potions(state, player)) or  # Water Breathing Potions for the Tide Armor Trim
-                state.has("Bucket", player))),  # Access to Milk and Axolotls for the Tide Armor Trim
+                (state.has("Bucket", player) and can_enchant(state, player)))),  # Access to Milk/Aqua Affinity and Axolotls/Respiration for the Tide Armor Trim
             "Respecting the Remnants": lambda state: can_excavate(state, player),
             "Careful Restoration": lambda state: can_excavate(state, player),
             "The Power of Books": lambda state: state.has("Progressive Tools", player, 2),


### PR DESCRIPTION
## What is this fixing or adding?
Adds a rule to Smithing with Style so that players need to be able to Enchant in addition to requiring a Bucket.
The practical application of this is that, when tackling an Ocean Monument, players can pair Milk to remove Mining Fatigue with Aqua Affinity to break through the walls, or alternatively, they can get Respiration to explore the Monument alongside Axolotls.

## How was this tested?
Ran a generation where Enchanting was obtained from Smithing with Style when it was unable to be completed otherwise and it successfully failed.